### PR TITLE
fix: change % to $ in date typo affecting wl-copy

### DIFF
--- a/lua/silicon/request.lua
+++ b/lua/silicon/request.lua
@@ -185,7 +185,7 @@ request.exec = function(show_buffer, copy_to_board, debug)
 		elseif vim.fn.executable("wl-copy") == 1 and copy_to_board then
 			-- Save output to /tmp then copy from there
 			table.insert(args, "--output")
-			opts.output = utils.replace_placeholders("/tmp/SILICON_${year}-${month}-%{date}_${time}.png")
+			opts.output = utils.replace_placeholders("/tmp/SILICON_${year}-${month}-${date}_${time}.png")
 			table.insert(args, opts.output)
 		else
 			table.insert(args, "--output")


### PR DESCRIPTION
This keeps shell paths from expanding on this formatting. Prior to this commit %{date} was not being replaced as the formatting function was expecting ${date}.

Very small change, but does fix behavior for those of us with wl-clipboard :).