### PR TITLE
Handle visual in a more compatible way

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,35 +63,57 @@ silicon comes with the following defaults:
 	shadowColor = "#555555",
 	shadowOffsetX = 8,
 	shadowOffsetY = 8,
-    gobble = false, -- enable lsautogobble like feature
+	gobble = false, -- enable lsautogobble like feature
+	debug = false, -- enable debug output
 }
 ```
 
 # 🚀 Usage
 
-1. Select code snippet in visual mode.
+## Keymaps
 
-- Generate images of selected snippet.
-
-```vim
-lua require("silicon").visualise_api({})
-```
-
-- Generate images of whole buffer with the selected snippet being highlighted by lighter background.
-
-```vim
-lua require("silicon").visualise_api({show_buf = true})
-```
-
-- Copy the image of snippet to clipboard.
-
-```vim
-lua require("silicon").visualise_api({to_clip = true})
-```
-
-**NOTE:** The default path of image is the current working directory of the editor, but you can change it by
 ```lua
-require("silicon").setup({
-        output = "/home/astro/Pictures/SILICON_$year-$month-$date-$time.png"),
-})
+-- Generate image of lines in a visual selection
+vim.keymap.set('v', '<Leader>s',  function() silicon.visualise_api() end )
+-- Generate image of a whole buffer, with lines in a visual selection highlighted
+vim.keymap.set('v', '<Leader>bs', function() silicon.visualise_api({to_clip = true, show_buf = true}) end )
+-- Generate visible portion of a buffer
+vim.keymap.set('n', '<Leader>s',  function() silicon.visualise_api({to_clip = true, visible = true}) end )
+-- Generate current buffer line in normal mode
+vim.keymap.set('n', '<Leader>s',  function() silicon.visualise_api({to_clip = true}) end )
 ```
+
+## Command line
+
+Calling `silicon.visualise_api` with `lua` in command line doesn't work due to `lua` not supporting ranges.  
+This means that the moment you hit enter, you leave visual mode before lua function is called. While this populates two registers, using them doesn't work with "v" mode maps.  
+A workaround has been implemented, and a shorthand that forces it is available as `.visualise_cmdline`:
+
+- Generate image of lines in a visual selection
+
+    ```lua
+    lua require('silicon').visualise_cmdline()
+    ```
+
+- Generate image of a whole buffer, with lines in a visual selection highlighted
+
+    ```lua
+    lua require('silicon').visualise_cmdline({to_clip = true, show_buf = true})
+    ```
+
+- Generate visible portion of a buffer
+
+    ```lua
+    lua require('silicon').visualise_cmdline({to_clip = true, visible = true})
+    ```
+
+
+## Notes
+
+- The default path of image is the current working directory of the editor, but you can change it by
+
+    ```lua
+    require("silicon").setup({
+            output = "/home/astro/Pictures/SILICON_$year-$month-$date-$time.png"),
+    })
+    ```

--- a/lua/silicon/config.lua
+++ b/lua/silicon/config.lua
@@ -18,6 +18,7 @@ config.opts = {
 	shadowOffsetX = 8,
 	shadowOffsetY = 8,
 	gobble = false,
+	debug = false,
 }
 
 --- @param opts table

--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -26,15 +26,37 @@ Try using require("silicon").visualise_api({show_buf = %s, to_clip = %s})
 end
 
 -- Similar to visualise
---- Generates image of selected
+--- Generates image of selected region
 ---[[
 -- show_buf boolean whether to show buffer
 -- to_clip boolean whether to show clipboard
--- debug show debug info
+-- visible boolean whether to render visible buffer
+-- cmdline boolean whether to work around cmdline issues
 ---]]
 ---@param opts table containing the options
 init.visualise_api = function(opts)
-	require("silicon.request").exec(opts.show_buf or false, opts.to_clip or false, opts.debug or false)
+	local range
+	if opts.visible then
+		range = { vim.fn.getpos('w0')[2], vim.fn.getpos('w$')[2] }
+	elseif opts.cmdline then -- deal with `lua` leaving visual before executing
+		range = { vim.api.nvim_buf_get_mark(0, "<")[1], vim.api.nvim_buf_get_mark(0, ">")[1] }
+	else
+		range = { vim.fn.getpos('v')[2], vim.fn.getpos('.')[2] }
+	end
+	require("silicon.request").exec(range, opts.show_buf or false, opts.to_clip or false)
+end
+
+--- Generates image of selected region
+--- But enforce cmdline workaround
+---[[
+-- show_buf boolean whether to show buffer
+-- to_clip boolean whether to show clipboard
+-- visible boolean whether to render visible buffer
+---]]
+---@param opts table containing the options
+init.visualise_cmdline = function(opts)
+	opts = vim.tbl_extend('keep', { cmdline = true }, opts)
+	init.visualise_api(opts)
 end
 
 return init

--- a/lua/silicon/request.lua
+++ b/lua/silicon/request.lua
@@ -56,8 +56,10 @@ utils.replace_placeholders = function(str)
 		:gsub("${date}", os.date("%d"))
 end
 
-request.exec = function(show_buffer, copy_to_board, debug)
-	local starting, ending = vim.api.nvim_buf_get_mark(0, "<")[1] - 1, vim.api.nvim_buf_get_mark(0, ">")[1]
+request.exec = function(range, show_buffer, copy_to_board)
+	table.sort(range)
+	local starting, ending = unpack(range)
+	starting = starting - 1
 
 	local lines = vim.api.nvim_buf_get_lines(0, starting, ending, true)
 
@@ -125,7 +127,7 @@ request.exec = function(show_buffer, copy_to_board, debug)
 			args = { "--build-cache" },
 			cwd = config_dir,
 			on_stderr = function(_, data, ...)
-				if debug then
+				if opts.debug then
 					print(vim.inspect(data))
 				end
 			end,
@@ -221,7 +223,7 @@ request.exec = function(show_buffer, copy_to_board, debug)
 				end
 			end,
 			on_stderr = function(_, data, ...)
-				if debug then
+				if opts.debug then
 					print(vim.inspect(data))
 				end
 			end,


### PR DESCRIPTION
Marks `<` and `>` are only populated on exiting visual mode, which kinda works with `lua` cmdline call, as it forcibly exists visual mode.

But keybindings don't do that, and as a result the plugin never accesses the visual selection that user is looking at.
This commit relegates marks usage to a cmdline mode, uses getpos instead, and implements a `visual` option to render visual portion of the buffer.

Debug flag got moved to configuration in order to keep `request.exec` function signature lean.

I did not attempt to handle block or char selections, as they seemed nonsensical. If that's ever needed, [nvim_buf_get_text](https://neovim.io/doc/user/api.html#nvim_buf_get_text()) could be utilised.

Closes #8 