### PR TITLE
Fix README.md colorscheme reloading example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ vim.api.nvim_create_autocmd({ 'ColorScheme' },
 	group = 'SiliconRefresh',
 	callback = function()
 		silicon_utils.build_tmTheme()
-		silicon_utils.reloadSiliconCache({async = true})
+		silicon_utils.reload_silicon_cache({async = true})
 	end,
 	desc = 'Reload silicon themes cache on colorscheme switch',
 	}


### PR DESCRIPTION
When extracting `reload_silicon_cache`, I'd fixed my initial name style mistake in code, but not in readme. This commit fixes colorscheme reloading example to a correct one.