### PR TITLE
Fix hex-code error in theme build logic

### DIFF
--- a/lua/silicon/build_tmTheme.lua
+++ b/lua/silicon/build_tmTheme.lua
@@ -14,7 +14,7 @@ local hl = function(hl_name, value)
 	if not hl[value] then
 		hl[value] = vim.api.nvim_get_hl_by_name("Normal", true)[value]
 	end
-	local color = string.format("#%x", hl[value])
+	local color = string.format("#%06x", hl[value])
 	return color
 end
 

--- a/lua/silicon/request.lua
+++ b/lua/silicon/request.lua
@@ -70,7 +70,7 @@ request.exec = function(range, show_buffer, copy_to_board)
 			goto skip_build
 		end
 		utils.build_tmTheme()
-		utils.reload_silicon_cache()
+		utils.reload_silicon_cache({async = false})
 	end
 
 	::skip_build::


### PR DESCRIPTION
**Fixes**: 
1. `attempt to index local 'opts' (a nil value)`
2. `Some error occurred while executing silicon` arising from bad hex codes in theme files