### PR TITLE
Make opts argument optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # silicon.lua
 
-**silicon** is a lua plugin for neovim to generate beautiful images of code snippet using [silicon](https://github.com/aloxaf/silicon) 
+**silicon** is a lua plugin for neovim to generate beautiful images of code snippet using [silicon](https://github.com/aloxaf/silicon)
 
 <video src = "https://user-images.githubusercontent.com/79555780/198016165-7a47ac6c-e329-4025-8d66-f9b34bd52658.mp4"></video>
 
@@ -74,7 +74,7 @@ silicon comes with the following defaults:
 
 ```lua
 -- Generate image of lines in a visual selection
-vim.keymap.set('v', '<Leader>s',  function() silicon.visualise_api({}) end )
+vim.keymap.set('v', '<Leader>s',  function() silicon.visualise_api() end )
 -- Generate image of a whole buffer, with lines in a visual selection highlighted
 vim.keymap.set('v', '<Leader>bs', function() silicon.visualise_api({to_clip = true, show_buf = true}) end )
 -- Generate visible portion of a buffer
@@ -91,31 +91,31 @@ A workaround has been implemented, and a shorthand that forces it is available a
 
 - Generate image of lines in a visual selection
 
-    ```lua
-    lua require('silicon').visualise_cmdline({})
-    ```
+  ```lua
+  lua require('silicon').visualise_cmdline()
+  ```
 
 - Generate image of a whole buffer, with lines in a visual selection highlighted
 
-    ```lua
-    lua require('silicon').visualise_cmdline({to_clip = true, show_buf = true})
-    ```
+  ```lua
+  lua require('silicon').visualise_cmdline({to_clip = true, show_buf = true})
+  ```
 
 - Generate visible portion of a buffer
 
-    ```lua
-    lua require('silicon').visualise_cmdline({to_clip = true, visible = true})
-    ```
+  ```lua
+  lua require('silicon').visualise_cmdline({to_clip = true, visible = true})
+  ```
 
 ## Notes
 
 - The default path of image is the current working directory of the editor, but you can change it by
 
-    ```lua
-    require("silicon").setup({
-            output = "/home/astro/Pictures/SILICON_$year-$month-$date-$time.png"),
-    })
-    ```
+  ```lua
+  require("silicon").setup({
+          output = "/home/astro/Pictures/SILICON_$year-$month-$date-$time.png"),
+  })
+  ```
 
 ## Colorscheme reloading
 

--- a/lua/silicon/build_tmTheme.lua
+++ b/lua/silicon/build_tmTheme.lua
@@ -9,12 +9,13 @@ local hl = function(hl_name, value)
 	if value == "bg" then
 		value = "background"
 	end
-        -- Default to foreground if no value is given
+	-- Default to foreground if no value is given
 	value = value or "foreground"
 	local hl = vim.api.nvim_get_hl_by_name(hl_name, true)
-        -- If highlight doesn't exist, default to the value for "Normal"
+	-- If highlight doesn't exist, default to the value for "Normal"
 	if not hl[value] then
-		hl[value] = vim.api.nvim_get_hl_by_name("Normal", true)[value] or vim.api.nvim_get_hl_by_name("Cursorline", true)[value]
+		hl[value] = vim.api.nvim_get_hl_by_name("Normal", true)[value]
+			or vim.api.nvim_get_hl_by_name("Cursorline", true)[value]
 	end
 	local color = string.format("#%06x", hl[value])
 	return color

--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -37,11 +37,11 @@ end
 init.visualise_api = function(opts)
 	local range
 	if opts.visible then
-		range = { vim.fn.getpos('w0')[2], vim.fn.getpos('w$')[2] }
+		range = { vim.fn.getpos("w0")[2], vim.fn.getpos("w$")[2] }
 	elseif opts.cmdline then -- deal with `lua` leaving visual before executing
 		range = { vim.api.nvim_buf_get_mark(0, "<")[1], vim.api.nvim_buf_get_mark(0, ">")[1] }
 	else
-		range = { vim.fn.getpos('v')[2], vim.fn.getpos('.')[2] }
+		range = { vim.fn.getpos("v")[2], vim.fn.getpos(".")[2] }
 	end
 	require("silicon.request").exec(range, opts.show_buf or false, opts.to_clip or false)
 end
@@ -55,7 +55,7 @@ end
 ---]]
 ---@param opts table containing the options
 init.visualise_cmdline = function(opts)
-	opts = vim.tbl_extend('keep', { cmdline = true }, opts)
+	opts = vim.tbl_extend("keep", { cmdline = true }, opts)
 	init.visualise_api(opts)
 end
 

--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -33,8 +33,9 @@ end
 -- visible boolean whether to render visible buffer
 -- cmdline boolean whether to work around cmdline issues
 ---]]
----@param opts table containing the options
+---@param opts? table containing the options
 init.visualise_api = function(opts)
+	opts = opts or {}
 	local range
 	if opts.visible then
 		range = { vim.fn.getpos("w0")[2], vim.fn.getpos("w$")[2] }
@@ -53,8 +54,9 @@ end
 -- to_clip boolean whether to show clipboard
 -- visible boolean whether to render visible buffer
 ---]]
----@param opts table containing the options
+---@param opts? table containing the options
 init.visualise_cmdline = function(opts)
+	opts = opts or {}
 	opts = vim.tbl_extend("keep", { cmdline = true }, opts)
 	init.visualise_api(opts)
 end

--- a/lua/silicon/request.lua
+++ b/lua/silicon/request.lua
@@ -1,5 +1,5 @@
 local opts = require("silicon.config").opts
-local utils = require('silicon.utils')
+local utils = require("silicon.utils")
 local Job = require("plenary.job")
 local fmt = string.format
 
@@ -34,34 +34,35 @@ request.exec = function(range, show_buffer, copy_to_board)
 
 	local textCode = table.concat(lines, "\n")
 
-  local default_themes = {
-"1337",
-"Coldark-Cold",
-"Coldark-Dark",
-"DarkNeon",
-"Dracula",
-"GitHub",
-"Monokai Extended",
-"Monokai Extended Bright",
-"Monokai Extended Light",
-"Monokai Extended Origin",
-"Nord",
-"OneHalfDark",
-"OneHalfLight",
-"Solarized (dark)",
-"Solarized (light)",
-"Sublime Snazzy",
-"TwoDark",
-"Visual Studio Dark+",
-"ansi",
-"base16",
-"base16-256"}
+	local default_themes = {
+		"1337",
+		"Coldark-Cold",
+		"Coldark-Dark",
+		"DarkNeon",
+		"Dracula",
+		"GitHub",
+		"Monokai Extended",
+		"Monokai Extended Bright",
+		"Monokai Extended Light",
+		"Monokai Extended Origin",
+		"Nord",
+		"OneHalfDark",
+		"OneHalfLight",
+		"Solarized (dark)",
+		"Solarized (light)",
+		"Sublime Snazzy",
+		"TwoDark",
+		"Visual Studio Dark+",
+		"ansi",
+		"base16",
+		"base16-256",
+	}
 
-	if string.lower(opts.theme) == "auto" or not(vim.tbl_contains(default_themes, opts.theme)) then
-        if string.match(utils._os_capture("silicon --version"), "%d+%.%d+%.%d+") < "0.5.1" then
-            vim.notify("silicon v0.5.1 or higher is required for automagically creating theme", vim.log.levels.ERROR)
-            return
-        end
+	if string.lower(opts.theme) == "auto" or not (vim.tbl_contains(default_themes, opts.theme)) then
+		if string.match(utils._os_capture("silicon --version"), "%d+%.%d+%.%d+") < "0.5.1" then
+			vim.notify("silicon v0.5.1 or higher is required for automagically creating theme", vim.log.levels.ERROR)
+			return
+		end
 		opts.theme = vim.g.colors_name .. "_" .. vim.o.background
 		if utils._exists(utils.themes_path) ~= true then
 			os.execute(fmt("mkdir -p %s %s", utils.themes_path, utils.syntaxes_path))
@@ -70,7 +71,7 @@ request.exec = function(range, show_buffer, copy_to_board)
 			goto skip_build
 		end
 		utils.build_tmTheme()
-		utils.reload_silicon_cache({async = false})
+		utils.reload_silicon_cache({ async = false })
 	end
 
 	::skip_build::

--- a/lua/silicon/utils.lua
+++ b/lua/silicon/utils.lua
@@ -73,7 +73,8 @@ utils.build_tmTheme = function()
 end
 
 utils._replace_placeholders = function(str)
-	return str:gsub("${time}", fmt("%s:%s", os.date("%H"), os.date("%M")))
+	return str
+		:gsub("${time}", fmt("%s:%s", os.date("%H"), os.date("%M")))
 		:gsub("${year}", os.date("%Y"))
 		:gsub("${month}", os.date("%m"))
 		:gsub("${date}", os.date("%d"))

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,4 @@
+indent_width = 2
+
+[sort_requires]
+enabled = true


### PR DESCRIPTION
This fixes #23 and reverts #31. 

As discussed in #31, `visualize_api()` now accepts an optional argument `opts`. If no opts are passed, we fall back to an empty table. The Readme and annotations have been updated accordingly.

Additionally, I added a [stylua](https://github.com/JohnnyMorganz/StyLua) config and formatted the code. In particular `requests.lua` had some code alignment issues that are now fixed. Formatting is a separate commit, for opts & readme change see 615bef1d178c5c46f21cea5255cee8626d15fdfb. 

P.S. I really like this plugin and use it pretty much daily. Thought since I'm opening a bunch of new issues I might as well fix some old ones. Hope it helps 🤗