### PR TITLE
Add highlight option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Plug 'narutoxy/silicon.lua'
 lua require('silicon').setup({})
 ```
 
-## ⚙️ Configuratioon
+## ⚙️ Configuration
 
 silicon comes with the following defaults:
 
@@ -76,7 +76,7 @@ silicon comes with the following defaults:
 -- Generate image of lines in a visual selection
 vim.keymap.set('v', '<Leader>s',  function() silicon.visualise_api() end )
 -- Generate image of a whole buffer, with lines in a visual selection highlighted
-vim.keymap.set('v', '<Leader>bs', function() silicon.visualise_api({to_clip = true, show_buf = true}) end )
+vim.keymap.set('v', '<Leader>bs', function() silicon.visualise_api({to_clip = true, show_buf = true, highlight = true}) end )
 -- Generate visible portion of a buffer
 vim.keymap.set('n', '<Leader>s',  function() silicon.visualise_api({to_clip = true, visible = true}) end )
 -- Generate current buffer line in normal mode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # silicon.lua
 
-**silicon** is a lua plugin for neovim to generate beautiful images of code snippet using [silicon](https://github.com/aloxaf/silicon) 
+**silicon** is a lua plugin for neovim to generate beautiful images of code snippet using [silicon](https://github.com/aloxaf/silicon)
 
 <video src = "https://user-images.githubusercontent.com/79555780/198016165-7a47ac6c-e329-4025-8d66-f9b34bd52658.mp4"></video>
 
@@ -74,7 +74,7 @@ silicon comes with the following defaults:
 
 ```lua
 -- Generate image of lines in a visual selection
-vim.keymap.set('v', '<Leader>s',  function() silicon.visualise_api({}) end )
+vim.keymap.set('v', '<Leader>s',  function() silicon.visualise_api() end )
 -- Generate image of a whole buffer, with lines in a visual selection highlighted
 vim.keymap.set('v', '<Leader>bs', function() silicon.visualise_api({to_clip = true, show_buf = true}) end )
 -- Generate visible portion of a buffer
@@ -91,31 +91,31 @@ A workaround has been implemented, and a shorthand that forces it is available a
 
 - Generate image of lines in a visual selection
 
-    ```lua
-    lua require('silicon').visualise_cmdline({})
-    ```
+  ```lua
+  lua require('silicon').visualise_cmdline()
+  ```
 
 - Generate image of a whole buffer, with lines in a visual selection highlighted
 
-    ```lua
-    lua require('silicon').visualise_cmdline({to_clip = true, show_buf = true})
-    ```
+  ```lua
+  lua require('silicon').visualise_cmdline({to_clip = true, show_buf = true})
+  ```
 
 - Generate visible portion of a buffer
 
-    ```lua
-    lua require('silicon').visualise_cmdline({to_clip = true, visible = true})
-    ```
+  ```lua
+  lua require('silicon').visualise_cmdline({to_clip = true, visible = true})
+  ```
 
 ## Notes
 
 - The default path of image is the current working directory of the editor, but you can change it by
 
-    ```lua
-    require("silicon").setup({
-            output = "/home/astro/Pictures/SILICON_$year-$month-$date-$time.png"),
-    })
-    ```
+  ```lua
+  require("silicon").setup({
+          output = "/home/astro/Pictures/SILICON_$year-$month-$date-$time.png"),
+  })
+  ```
 
 ## Colorscheme reloading
 

--- a/lua/silicon/build_tmTheme.lua
+++ b/lua/silicon/build_tmTheme.lua
@@ -9,12 +9,13 @@ local hl = function(hl_name, value)
 	if value == "bg" then
 		value = "background"
 	end
-        -- Default to foreground if no value is given
+	-- Default to foreground if no value is given
 	value = value or "foreground"
 	local hl = vim.api.nvim_get_hl_by_name(hl_name, true)
-        -- If highlight doesn't exist, default to the value for "Normal"
+	-- If highlight doesn't exist, default to the value for "Normal"
 	if not hl[value] then
-		hl[value] = vim.api.nvim_get_hl_by_name("Normal", true)[value] or vim.api.nvim_get_hl_by_name("Cursorline", true)[value]
+		hl[value] = vim.api.nvim_get_hl_by_name("Normal", true)[value]
+			or vim.api.nvim_get_hl_by_name("Cursorline", true)[value]
 	end
 	local color = string.format("#%06x", hl[value])
 	return color

--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -37,11 +37,11 @@ end
 init.visualise_api = function(opts)
 	local range
 	if opts.visible then
-		range = { vim.fn.getpos('w0')[2], vim.fn.getpos('w$')[2] }
+		range = { vim.fn.getpos("w0")[2], vim.fn.getpos("w$")[2] }
 	elseif opts.cmdline then -- deal with `lua` leaving visual before executing
 		range = { vim.api.nvim_buf_get_mark(0, "<")[1], vim.api.nvim_buf_get_mark(0, ">")[1] }
 	else
-		range = { vim.fn.getpos('v')[2], vim.fn.getpos('.')[2] }
+		range = { vim.fn.getpos("v")[2], vim.fn.getpos(".")[2] }
 	end
 	require("silicon.request").exec(range, opts.show_buf or false, opts.to_clip or false)
 end
@@ -55,7 +55,7 @@ end
 ---]]
 ---@param opts table containing the options
 init.visualise_cmdline = function(opts)
-	opts = vim.tbl_extend('keep', { cmdline = true }, opts)
+	opts = vim.tbl_extend("keep", { cmdline = true }, opts)
 	init.visualise_api(opts)
 end
 

--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -33,8 +33,9 @@ end
 -- visible boolean whether to render visible buffer
 -- cmdline boolean whether to work around cmdline issues
 ---]]
----@param opts table containing the options
+---@param opts? table containing the options
 init.visualise_api = function(opts)
+	opts = opts or {}
 	local range
 	if opts.visible then
 		range = { vim.fn.getpos("w0")[2], vim.fn.getpos("w$")[2] }
@@ -53,8 +54,9 @@ end
 -- to_clip boolean whether to show clipboard
 -- visible boolean whether to render visible buffer
 ---]]
----@param opts table containing the options
+---@param opts? table containing the options
 init.visualise_cmdline = function(opts)
+	opts = opts or {}
 	opts = vim.tbl_extend("keep", { cmdline = true }, opts)
 	init.visualise_api(opts)
 end

--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -7,9 +7,10 @@ end
 -- For backwards compatibility
 -- Generates image of selected
 ---@param show_buf boolean whether to show buffer
+---@param highlight boolean whether to show hightlight
 ---@param to_clip boolean whether to show clipboard
-init.visualise = function(show_buf, to_clip)
-	init.visualise_api({ show_buf = show_buf, to_clip = to_clip })
+init.visualise = function(show_buf, highlight, to_clip)
+	init.visualise_api({ show_buf = show_buf, highlight = highlight, to_clip = to_clip })
 	vim.notify(
 		string.format(
 			[[
@@ -29,6 +30,7 @@ end
 --- Generates image of selected region
 ---[[
 -- show_buf boolean whether to show buffer
+-- highlight boolean whether to highlight lines
 -- to_clip boolean whether to show clipboard
 -- visible boolean whether to render visible buffer
 -- cmdline boolean whether to work around cmdline issues
@@ -44,13 +46,14 @@ init.visualise_api = function(opts)
 	else
 		range = { vim.fn.getpos("v")[2], vim.fn.getpos(".")[2] }
 	end
-	require("silicon.request").exec(range, opts.show_buf or false, opts.to_clip or false)
+	require("silicon.request").exec(range, opts.show_buf or false, opts.to_clip or false, opts.highlight or false)
 end
 
 --- Generates image of selected region
 --- But enforce cmdline workaround
 ---[[
 -- show_buf boolean whether to show buffer
+-- highlight boolean whether to highlight lines
 -- to_clip boolean whether to show clipboard
 -- visible boolean whether to render visible buffer
 ---]]

--- a/lua/silicon/request.lua
+++ b/lua/silicon/request.lua
@@ -1,11 +1,15 @@
 local opts = require("silicon.config").opts
-local utils = require("silicon.utils")
 local Job = require("plenary.job")
+local utils = require("silicon.utils")
 local fmt = string.format
 
 local request = {}
 
-request.exec = function(range, show_buffer, copy_to_board)
+---@param range {} range of lines
+---@param show_buffer boolean whether to show buffer
+---@param copy_to_board boolean whether to show clipboard
+---@param highlight boolean whether to show hightlight
+request.exec = function(range, show_buffer, copy_to_board, highlight)
 	table.sort(range)
 	local starting, ending = unpack(range)
 	starting = starting - 1
@@ -23,8 +27,7 @@ request.exec = function(range, show_buffer, copy_to_board)
 		for idx = 1, #lines do
 			lines[idx] = lines[idx]:gsub("\t", string.rep(" ", vim.bo.tabstop))
 			current_whitespace = string.len(string.match(lines[idx], "^[\r\n\t\f\v ]*") or "")
-			whitespace = current_whitespace < (whitespace or current_whitespace + 1) and current_whitespace
-				or whitespace
+			whitespace = current_whitespace < (whitespace or current_whitespace + 1) and current_whitespace or whitespace
 		end
 		-- Now remove whitespace
 		for idx = 1, #lines do
@@ -118,7 +121,7 @@ request.exec = function(range, show_buffer, copy_to_board)
 			table.insert(args, "--background")
 			table.insert(args, opts.bgColor)
 		end
-		if show_buffer then
+		if highlight then
 			table.insert(args, "--highlight-lines")
 			table.insert(args, fmt("%s-%s", starting + 1, ending))
 		end
@@ -154,11 +157,7 @@ request.exec = function(range, show_buffer, copy_to_board)
 					end, 0)
 				else
 					vim.defer_fn(function()
-						vim.notify(
-							"Some error occured while executing silicon",
-							vim.log.levels.ERROR,
-							{ plugin = "silicon.lua" }
-						)
+						vim.notify("Some error occured while executing silicon", vim.log.levels.ERROR, { plugin = "silicon.lua" })
 					end, 0)
 				end
 			end,

--- a/lua/silicon/request.lua
+++ b/lua/silicon/request.lua
@@ -1,5 +1,5 @@
 local opts = require("silicon.config").opts
-local utils = require('silicon.utils')
+local utils = require("silicon.utils")
 local Job = require("plenary.job")
 local fmt = string.format
 
@@ -34,34 +34,35 @@ request.exec = function(range, show_buffer, copy_to_board)
 
 	local textCode = table.concat(lines, "\n")
 
-  local default_themes = {
-"1337",
-"Coldark-Cold",
-"Coldark-Dark",
-"DarkNeon",
-"Dracula",
-"GitHub",
-"Monokai Extended",
-"Monokai Extended Bright",
-"Monokai Extended Light",
-"Monokai Extended Origin",
-"Nord",
-"OneHalfDark",
-"OneHalfLight",
-"Solarized (dark)",
-"Solarized (light)",
-"Sublime Snazzy",
-"TwoDark",
-"Visual Studio Dark+",
-"ansi",
-"base16",
-"base16-256"}
+	local default_themes = {
+		"1337",
+		"Coldark-Cold",
+		"Coldark-Dark",
+		"DarkNeon",
+		"Dracula",
+		"GitHub",
+		"Monokai Extended",
+		"Monokai Extended Bright",
+		"Monokai Extended Light",
+		"Monokai Extended Origin",
+		"Nord",
+		"OneHalfDark",
+		"OneHalfLight",
+		"Solarized (dark)",
+		"Solarized (light)",
+		"Sublime Snazzy",
+		"TwoDark",
+		"Visual Studio Dark+",
+		"ansi",
+		"base16",
+		"base16-256",
+	}
 
-	if string.lower(opts.theme) == "auto" or not(vim.tbl_contains(default_themes, opts.theme)) then
-        if string.match(utils._os_capture("silicon --version"), "%d+%.%d+%.%d+") < "0.5.1" then
-            vim.notify("silicon v0.5.1 or higher is required for automagically creating theme", vim.log.levels.ERROR)
-            return
-        end
+	if string.lower(opts.theme) == "auto" or not (vim.tbl_contains(default_themes, opts.theme)) then
+		if string.match(utils._os_capture("silicon --version"), "%d+%.%d+%.%d+") < "0.5.1" then
+			vim.notify("silicon v0.5.1 or higher is required for automagically creating theme", vim.log.levels.ERROR)
+			return
+		end
 		opts.theme = vim.g.colors_name .. "_" .. vim.o.background
 		if utils._exists(utils.themes_path) ~= true then
 			os.execute(fmt("mkdir -p %s %s", utils.themes_path, utils.syntaxes_path))
@@ -70,7 +71,7 @@ request.exec = function(range, show_buffer, copy_to_board)
 			goto skip_build
 		end
 		utils.build_tmTheme()
-		utils.reload_silicon_cache({async = false})
+		utils.reload_silicon_cache({ async = false })
 	end
 
 	::skip_build::

--- a/lua/silicon/utils.lua
+++ b/lua/silicon/utils.lua
@@ -73,7 +73,8 @@ utils.build_tmTheme = function()
 end
 
 utils._replace_placeholders = function(str)
-	return str:gsub("${time}", fmt("%s:%s", os.date("%H"), os.date("%M")))
+	return str
+		:gsub("${time}", fmt("%s:%s", os.date("%H"), os.date("%M")))
 		:gsub("${year}", os.date("%Y"))
 		:gsub("${month}", os.date("%m"))
 		:gsub("${date}", os.date("%d"))

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,4 @@
+indent_width = 2
+
+[sort_requires]
+enabled = true


### PR DESCRIPTION
Currently, setting `show_buf` is also used to pass the highlight option to Silicone. Unfortunately, that means that is impossible to create images of the whole buffer _without_ any visual highlights as the line with the cursor is always highlighted. 

## Solution

This PR adds a new opt `highlight` to control whether lines should be highlighted or not. When set, the behaviour is identical to the previous one. The visual selection will be highlighted. If it is not set, then no highlight. Duh.

The Readme has been updated. I snuck in a typo fix and some formatting as well. 

### Buffer with Highlight

```lua
require("silicon").visualise_api({ to_clip = true, show_buf = true, highlight=true})
```
![Code_2025032520:47](https://github.com/user-attachments/assets/1d730c5a-4fb4-4183-987b-b414f9a39cf5)
### Without Highlight

```lua
require("silicon").visualise_api({ to_clip = true, show_buf = true })
```

![Code_2025032520:49](https://github.com/user-attachments/assets/cf8acf3d-bec4-4462-b7e8-54dbcd7a20f0)
eadme